### PR TITLE
fix `Kavenegar` response key

### DIFF
--- a/src/Drivers/Kavenegar/KavenegarConnector.php
+++ b/src/Drivers/Kavenegar/KavenegarConnector.php
@@ -97,7 +97,7 @@ class KavenegarConnector implements DriverConnector
         $response = $this->performApi($url);
 
         return collect($response->entries)->map(function ($item) {
-            return $this->generateReportResponse($item->message_id, $item->receptor, $item->message, $item->date, $item->sender, $item->cost);
+            return $this->generateReportResponse($item->messageid, $item->receptor, $item->message, $item->date, $item->sender, $item->cost, $item->statustext);
         });
     }
 

--- a/src/Traits/HasResponse.php
+++ b/src/Traits/HasResponse.php
@@ -51,9 +51,8 @@ trait HasResponse
         ];
     }
 
-    public function generateReportResponse($message_id, $receptor, $content, $sent_date, $line_number, $cost = null): object
+    public function generateReportResponse($message_id, $receptor, $content, $sent_date, $line_number, $cost = null, $status_text = null): object
     {
-
         return (object) [
             'message_id' => $message_id,
             'receptor' => $receptor,
@@ -61,7 +60,7 @@ trait HasResponse
             'sent_date' => $sent_date,
             'line_number' => $line_number,
             'cost' => $cost,
-
+            'status_text' => $status_text,
         ];
     }
 }


### PR DESCRIPTION
Hi,  

This pull request updates the Kavenegar response key and add `statustext` nullable to identify the operator used for sending messages.

Let me know if you need more details!







