### PR TITLE
Add `request_options` support to Sms.ir driver configuration

### DIFF
--- a/config/chapaar.php
+++ b/config/chapaar.php
@@ -46,6 +46,9 @@ return [
             'url' => 'https://api.sms.ir/v1/',
             'api_key' => '',
             'line_number' => '',
+            'request_options' => [
+                 // \GuzzleHttp\RequestOptions::VERIFY => false,
+            ],
         ],
         /* Configuration for the 'ghasedak' driver */
         'ghasedak' => [

--- a/src/Drivers/SmsIr/SmsIrConnector.php
+++ b/src/Drivers/SmsIr/SmsIrConnector.php
@@ -20,6 +20,7 @@ class SmsIrConnector implements DriverConnector
     {
         self::$setting = (object) config('chapaar.drivers.smsir');
         $this->client = new Client([
+            ...self::$setting->request_options ?? [],
             RequestOptions::HEADERS => [
                 'x-api-key' => self::$setting->api_key,
                 'Accept' => 'text/plain',


### PR DESCRIPTION
Hi,

This pull request adds a new `request_options` key to the **Sms.ir Driver** configuration.

In some cases, when calling APIs, additional request options are required—for example, disabling SSL verification.
With this change, developers can now pass request options directly from the configuration to the driver, making the integration more flexible and customizable.

